### PR TITLE
fix: Checkout latest tag to avoid never publishing a stable version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,6 @@ description: |
 
   NetBird log, config and socket files are stored in /var/snap/netbird/common
 
-grade: devel
 confinement: strict
 
 architectures:
@@ -56,12 +55,15 @@ parts:
     override-pull: |
       craftctl default
 
-      # set version and grade from code
+      # Checkout latest tagged version
       git config --global --add safe.directory '*'
+      latest_tag=$(git describe --tags)
+      echo "Checking out ${latest_tag}"
+      git checkout "${latesttag}"
+      # set version and grade from code
       version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
-      [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
       craftctl set version="$version"
-      craftctl set grade="$grade"
+      craftctl set grade="stable"
     override-build: |
       # Change default socket location
       for entry in client/cmd/root.go client/ui/client_ui.go; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
   netbird:
     plugin: go
     source: https://github.com/netbirdio/netbird.git
+    source-tag: "v0.37.1"
     build-snaps: [go]
     build-packages:
       - libayatana-appindicator3-dev
@@ -57,11 +58,8 @@ parts:
 
       # Checkout latest tagged version
       git config --global --add safe.directory '*'
-      latest_tag=$(git describe --tags)
-      echo "Checking out ${latest_tag}"
-      git checkout "${latest_tag}"
       # set version and grade from code
-      version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
+      version="$(git describe --always --tags| sed -e 's/^v//;y/-/./')"
       craftctl set version="$version"
       craftctl set grade="stable"
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
       git config --global --add safe.directory '*'
       latest_tag=$(git describe --tags)
       echo "Checking out ${latest_tag}"
-      git checkout "${latesttag}"
+      git checkout "${latest_tag}"
       # set version and grade from code
       version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
       craftctl set version="$version"


### PR DESCRIPTION
The Netbird snap was not getting uploaded on candidate since the grade was mostly set to 'devel'.

The reason for that is that we build weekly from the `main` branch. Since it's unlikely that the latest commit has been tagged we were never building a stable release.

Instead now, we only build from the latest tag and as a `stable` grade.