### PR TITLE
Add upstream release monitoring job

### DIFF
--- a/.github/workflows/monitor-upstream.yml
+++ b/.github/workflows/monitor-upstream.yml
@@ -1,0 +1,10 @@
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  monitor-upstream-release:
+    uses: canonical/robotics-actions-workflows/.github/workflows/simple-upstream-monitor.yaml@feat/upstream-sync
+    with:
+      source-repo: "netbirdio/netbird"

--- a/.github/workflows/monitor-upstream.yml
+++ b/.github/workflows/monitor-upstream.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   monitor-upstream-release:
-    uses: canonical/robotics-actions-workflows/.github/workflows/simple-upstream-monitor.yaml@feat/upstream-sync
+    uses: canonical/robotics-actions-workflows/.github/workflows/simple-upstream-monitor.yaml@main
     with:
       source-repo: "netbirdio/netbird"

--- a/.github/workflows/monitor-upstream.yml
+++ b/.github/workflows/monitor-upstream.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   monitor-upstream-release:
-    uses: canonical/robotics-actions-workflows/.github/workflows/simple-upstream-monitor.yaml@main
+    uses: canonical/robotics-actions-workflows/.github/workflows/upstream-gh-tag-monitor.yaml@main
     with:
       source-repo: "netbirdio/netbird"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,8 +1,6 @@
-name: Weekly builds
+name: snap
 
 on:
-  schedule:
-    - cron: '0 0 * * 0'
   push:
     tags:
       - '*'

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,7 @@ jobs:
       # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
       SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/
@@ -41,7 +41,7 @@ jobs:
             echo "Error: The number of '.txt' files and '.snap' files do not match."
             exit 1
           fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload snapcraft logs
         if: always()
         with:
@@ -50,7 +50,7 @@ jobs:
             /home/runner/.cache/snapcraft/log/
             /home/runner/.local/state/snapcraft/log/
             netbird-*.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload the snap as artifact
         with:
           name: netbird-snaps
@@ -64,7 +64,7 @@ jobs:
       matrix:
         architectures: [amd64, arm64]
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: netbird-snaps
         path: .


### PR DESCRIPTION
The weekly is renamed to 'snap' and now only triggers on pr/push.
Add a job to daily monitor new upstream tag.
Bump the actions (checkout/upload/download) to v4. The latter 2 's v3 [are deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).