### PR TITLE
Fix apparmor log rotation denial

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# The layout for the log file/folder has changed.
+# We thus make sure that existing logs are migrated to the new location
+if [ -f "$SNAP_COMMON/client.log" ]; then
+  mv "$SNAP_COMMON/client.log" "$SNAP_COMMON/var/log/netbird/."
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,8 +33,8 @@ architectures:
 layout:
   /etc/netbird:
     bind: $SNAP_COMMON
-  /var/log/netbird/client.log:
-    bind-file: $SNAP_COMMON/client.log
+  /var/log/netbird:
+    bind: $SNAP_COMMON/var/log/netbird
 
 parts:
   netbird:


### PR DESCRIPTION
The client tries to rotate the logs (`/var/log/netbird/client.log` -> `/var/log/netbird/client-<date>.log.gz`) but the access to write the archive is denied by apparmor. This PR fixes this by changing the log layout from binding a file to a directory.
The log directory is also changed from `$SNAP_COMMON/` to `$SNAP_COMMON/var/log/`.

A `post-refresh` hook is added to help migrate to the new directory.

Successfully tested locally.

Journal extract:

```bash
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35876): apparmor="DENIED" operation="rename_dest" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/client-2025-06-13T>
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35877): apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird>
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35878): apparmor="DENIED" operation="rename_dest" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/client-2025-06-13T>
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35879): apparmor="DENIED" operation="rename_dest" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/client-2025-06-13T>
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35880): apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird>
Jun 13 14:57:29 computer kernel: audit: type=1400 audit(1749819449.603:35881): apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird>
Jun 13 14:57:29 computer audit[78455]: AVC apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird" requested_mask="r" denied_mask="r">
Jun 13 14:57:29 computer audit[78455]: AVC apparmor="DENIED" operation="rename_dest" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/client-2025-06-13T12-57-29.605.log" pid=78455 comm="ne>
Jun 13 14:57:29 computer audit[78455]: AVC apparmor="DENIED" operation="rename_dest" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/client-2025-06-13T12-57-29.605.log" pid=78455 comm="ne>
Jun 13 14:57:29 computer audit[78455]: AVC apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird" requested_mask="r" denied_mask="r">
Jun 13 14:57:29 computer audit[78455]: AVC apparmor="DENIED" operation="open" class="file" profile="snap.netbird.service-run" name="/var/log/netbird/" pid=78455 comm="netbird" requested_mask="r" denied_mask="r">
Jun 13 14:57:29 computer netbird.service-run[78455]: Failed to write to log, can't rename log file: rename /var/log/netbird/client.log /var/log/netbird/client-2025-06-13T12-57-29.605.log: permission denied
Jun 13 14:57:29 computer netbird.service-run[78455]: Failed to write to log, can't rename log file: rename /var/log/netbird/client.log /var/log/netbird/client-2025-06-13T12-57-29.605.log: permission denied
Jun 13 14:57:36 computer netbird.service-run[78455]: Failed to write to log, can't rename log file: rename /var/log/netbird/client.log /var/log/netbird/client-2025-06-13T12-57-36.192.log: permission denied
```