### PR TITLE
Add layout /var/lib/netbird

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ layout:
     bind: $SNAP_COMMON
   /var/log/netbird:
     bind: $SNAP_COMMON/var/log/netbird
+  /var/lib/netbird:
+    bind: $SNAP_COMMON/var/lib/netbird
 
 parts:
   netbird:


### PR DESCRIPTION
Netbird recently added a 'profile' feature that lets user switch between different configs. Those are stored in `/var/lib/netbird` which is being binded to a location that's accessible to the snap in this PR.