### PR TITLE
disable riscv

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -85,7 +85,7 @@ jobs:
     needs: [snap-test]
     strategy:
       matrix:
-        architectures: [amd64, arm64, riscv64]
+        architectures: [amd64, arm64] # riscv64
     steps:
     - uses: actions/download-artifact@v4
       with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ confinement: strict
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]
-  - build-on: [riscv64]
+  # - build-on: [riscv64]
 
 layout:
   /etc/netbird:


### PR DESCRIPTION
Remote build for riscv is too wobly at the moment and keeps failing after long builds.