### PR TITLE
[hermes-agent] ci: migrate snap workflow to GH runners via robotics-actions-workflows

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -12,90 +12,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  snap-build:
-    name: Remote build snaps
-    runs-on: [ubuntu-latest]
-    env:
-      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
-      SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add LP credentials
-        run: |
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
-          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
-          git config --global user.email "canonical-robotics-brand@canonical.com"
-          git config --global user.name "Canonical robotics"
-      - name: snapcraft
-        env:
-          SNAPCRAFT_REMOTE_BUILD_STRATEGY: force-fallback
-        run: |
-          sudo snap install snapcraft --classic
-          snapcraft remote-build --launchpad-accept-public-upload --build-id netbird-${{ env.SNAPCRAFT_BUILDER_ID }}
-      - name: check number of built snaps
-        run: |
-          count_txt_files=$(find . -type f -name 'netbird_*.txt' | wc -l)
-          count_snap_files=$(find . -type f -name 'netbird_*.snap' | wc -l)
-          if [ "$count_txt_files" -ne "$count_snap_files" ]; then
-            echo "Error: The number of '.txt' files and '.snap' files do not match."
-            exit 1
-          fi
-      - uses: actions/upload-artifact@v4
-        name: Upload snapcraft logs
-        if: always()
-        with:
-          name: snapcraft_logs
-          path: |
-            /home/runner/.cache/snapcraft/log/
-            /home/runner/.local/state/snapcraft/log/
-            netbird-*.txt
-      - uses: actions/upload-artifact@v4
-        name: Upload the snap as artifact
-        with:
-          name: netbird-snaps
-          path: ./*.snap
-
-  snap-test:
-    runs-on: ubuntu-latest
-    needs: [snap-build]
-    strategy:
-      matrix:
-        architectures: [amd64]
-    steps:
-    - name: Download snaps
-      uses: actions/download-artifact@v4
-      with:
-        name: netbird-snaps
-        path: .
-    - name: Install snap
-      run: sudo snap install --dangerous netbird_*_${{ matrix.architectures }}.snap
-    - name: Test snap
-      run: |
+  snap:
+    uses: canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main
+    secrets:
+      snapstore-login: ${{ secrets.STORE_LOGIN }}
+    with:
+      # Build/test on GitHub-hosted amd64 + arm64 runners (no remote-build)
+      runs-on: '["ubuntu-latest", "ubuntu-24.04-arm"]'
+      snap-risk: candidate
+      snap-test-script: |
+        #!/bin/bash
         set -euxo pipefail
 
         snap info netbird
         snap services netbird | grep -Eq 'enabled\s+active'
 
         netbird status
-
-  snap-publish:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: [snap-test]
-    strategy:
-      matrix:
-        architectures: [amd64, arm64] # riscv64
-    steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: netbird-snaps
-        path: .
-    - name: Get snap filename
-      run: echo "SNAPFILE=$(ls netbird_*_${{ matrix.architectures }}.snap)" >> $GITHUB_ENV
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      with:
-        snap: ${{ env.SNAPFILE }}
-        release: candidate


### PR DESCRIPTION
[hermes-agent]

## Summary
- Replace the custom `remote-build` workflow with `canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main`.
- Build/test on GitHub-hosted amd64 and arm64 runners via:
  - `ubuntu-latest`
  - `ubuntu-24.04-arm`
- Keep candidate publication behavior by setting `snap-risk: candidate`.
- Preserve the existing runtime smoke test as `snap-test-script` (`snap info`, active service check, `netbird status`).

## Why
`remote-build` is no longer needed now that official GitHub arm runners are available.

## Test plan
- CI run for this PR should execute the reusable robotics workflow matrix on both runner types.
- Verify the PR checks reach green.
